### PR TITLE
feat<config>: fix next.js build config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# lockfile
+yarn.lock
+package-lock.json
+pnpm-lock.yaml

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@
 const nextConfig = {
   output: "export",
   useFileSystemPublicRoutes: false,
+  distDir: "build",
 };
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  distDir: "build",
+  output: "export",
+  useFileSystemPublicRoutes: false,
 };
 
 export default nextConfig;


### PR DESCRIPTION
- fix: next.config setup for static build
  - set output type to `export`
  - set file system public routes to `false`
  - keep destination directory on `build`
- docs: .gitignore
  - added node.js lockfile (from npm, yarn and pnpm)